### PR TITLE
Extract sprite image path to its own variable

### DIFF
--- a/net.creative-tweet.library.js
+++ b/net.creative-tweet.library.js
@@ -134,12 +134,15 @@ cssSpriteGenerator.getSpriteValue = function( _type ) {
 		spriteVariable = '',
 		imagePath = '../img/' + [artboard name] + '.png';
 
+	spritePathVariableName = prefix + [artboard name] + '-path';
+	spriteVariable += spritePathVariableName + sepalator + ' \'' + imagePath + '\';\n';
+
 	for (var i = [layers count] - 1; i >= 0; i--) {
 		var layer = [layers objectAtIndex:i];
 			spriteVariable += prefix + [layer name] + sepalator
 						    + ' ' + [[layer frame] width] + 'px' 
 						    + ' ' + [[layer frame] height] + 'px'
-						    + ' \'' + imagePath + '\''
+						    + ' ' + spritePathVariableName
 						    + ' ' + ( 0 - [[layer frame] x] ) + 'px' 
 						    + ' ' + ( 0 - [[layer frame] y] ) + 'px' 
 						    + ';\n';


### PR DESCRIPTION
I have different image path from the default one, and having to
change that path for every sprite images is quite a pain.
- Move hard code sprite path to variable for easy modification

result would be something like

```
$sprite-path: '../images/sprite.png';
$sprite1: 40px 42px $sprite-path -98px 0px;
$sprite2: 107px 30px $sprite-path -138px 0px;
$sprite3: 30px 32px $sprite-path -68px 0px;
...
```
